### PR TITLE
various small changes and fixes

### DIFF
--- a/src/NuxeoClient/Client.cs
+++ b/src/NuxeoClient/Client.cs
@@ -516,11 +516,11 @@ namespace NuxeoClient
         {
             if (data == null)
             {
-                throw new NullReferenceException("data parameter was null.");
+                throw new ArgumentNullException("data","data parameter was null.");
             }
             if (input == null)
             {
-                throw new NullReferenceException("input was null.");
+                throw new ArgumentNullException("input","input was null.");
             }
 
             HttpRequestMessage request = new HttpRequestMessage(htttpMethod ?? HttpMethod.Post, (endpoint.StartsWith("/") ? endpoint.Substring(1) : endpoint));
@@ -544,11 +544,11 @@ namespace NuxeoClient
         {
             if (data == null)
             {
-                throw new NullReferenceException("data parameter was null.");
+                throw new ArgumentNullException("data","data parameter was null.");
             }
             if (input == null)
             {
-                throw new NullReferenceException("input was null.");
+                throw new ArgumentNullException("input","input was null.");
             }
 
             HttpRequestMessage request = new HttpRequestMessage(htttpMethod ?? HttpMethod.Post, (endpoint.StartsWith("/") ? endpoint.Substring(1) : endpoint));
@@ -574,6 +574,8 @@ namespace NuxeoClient
 
         private void AddBlobToMultipartContent(MultipartContent content, Blob blob)
         {
+            if (blob.File == null) throw new ArgumentNullException("blob.File", "input blob has no file");
+            if (!blob.File.Exists) throw new FileNotFoundException(blob.File.FullName);
             HttpContent part = new StreamContent(blob.File.OpenRead());
             part.Headers.ContentType = new MediaTypeHeaderValue(blob.MimeType);
             part.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")

--- a/src/NuxeoClient/Operation.cs
+++ b/src/NuxeoClient/Operation.cs
@@ -17,6 +17,7 @@
  *     Gabriel Barata <gbarata@nuxeo.com>
  */
 
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuxeoClient.Wrappers;
 using System.Collections.Generic;
@@ -95,6 +96,16 @@ namespace NuxeoClient
             Parameters = null;
             Context = null;
             Endpoint = UrlCombiner.Combine(this.client.AutomationPath, Id);
+        }
+        /// <summary>
+        /// Sets the operation input.
+        /// </summary>
+        /// <param name="input">The operation input.</param>
+        /// <returns>The current <see cref="Operation"/> instance.</returns>
+        public Operation SetInput<T>(T input) where T:Entity
+        {
+            Input = JToken.Parse(JsonConvert.SerializeObject(input));
+            return this;
         }
 
         /// <summary>
@@ -175,6 +186,26 @@ namespace NuxeoClient
             return this;
         }
 
+        /// <summary>
+        /// Sets a parameter <see cref="Documents"/>
+        /// </summary>
+        /// <param name="property">The property's name.</param>
+        /// <param name="value">The <see cref="Documents"/> to use.</param>
+        /// <returns>The current <see cref="Operation"/> instance.</returns>
+        public Operation SetParameter(string property,Documents value)
+        {
+            return SetParameter(property, JToken.Parse(JsonConvert.SerializeObject(value)));
+        }
+        /// <summary>
+        /// Sets a parameter <see cref="Document"/>
+        /// </summary>
+        /// <param name="property">The property's name.</param>
+        /// <param name="value">The <see cref="Document"/> to use.</param>
+        /// <returns>The current <see cref="Operation"/> instance.</returns>
+        public Operation SetParameter(string property,Document value)
+        {
+            return SetParameter(property, JToken.Parse(JsonConvert.SerializeObject(value)));
+        }
         /// <summary>
         /// Sets a parameter property.
         /// </summary>
@@ -395,7 +426,7 @@ namespace NuxeoClient
 
             if (Input != null && !isBlob && !isBlobList)
             {
-                data.Add("input", (string)Input);
+                data.Add("input", (JToken)Input);
             }
 
             if (isBlob)

--- a/src/NuxeoClient/Wrappers/Blob.cs
+++ b/src/NuxeoClient/Wrappers/Blob.cs
@@ -47,7 +47,7 @@ namespace NuxeoClient.Wrappers
         public bool IsChunk { get; private set; } = false;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="Blob"/>.
+        /// Initializes a new instance of <see cref="Blob"/> with no FileInfo.
         /// </summary>
         /// <param name="filename">The name of the file it represents.</param>
         public Blob(string filename) :


### PR DESCRIPTION
* Allow operation to take document(s) as parameter
* Allow operation to take any entity as input
* Fix casting issue in execute on operation (JToken instead of string)
* Clarify Blob constructor overload that doesn't populate FileInfo
* throw ArgumentNullException instead of NullReferenceException when using Operation.Execute Blob code paths